### PR TITLE
Store location of the codeql result in DB

### DIFF
--- a/src/types/codeql.go
+++ b/src/types/codeql.go
@@ -9,11 +9,34 @@ type Run struct {
 }
 
 type Result struct {
-	RuleId    string  `json:"ruleId"`
-	RuleIndex int     `json:"ruleIndex"`
-	Message   Message `json:"message"`
+	RuleId    string     `json:"ruleId"`
+	RuleIndex int        `json:"ruleIndex"`
+	Message   Message    `json:"message"`
+	Locations []Location `json:"locations"`
 }
 
 type Message struct {
 	Text string `json:"text"`
+}
+
+type Location struct {
+	PhysicalLocation PhysicalLocation `json:"physicalLocation"`
+}
+
+type PhysicalLocation struct {
+	ArtifactLocation ArtifactLocation `json:"artifactLocation"`
+	Region           Region           `json:"region"`
+}
+
+type ArtifactLocation struct {
+	URI       string `json:"uri"`
+	URIBaseId string `json:"uriBaseId"`
+	Index     int    `json:"index"`
+}
+
+type Region struct {
+	StartLine   int `json:"startLine"`
+	EndLine     int `json:"endLine"`
+	StartColumn int `json:"startColumn"`
+	EndColumn   int `json:"endColumn"`
 }


### PR DESCRIPTION
We retrieves more information to be able to tell the user at what line and column the problem was discovered